### PR TITLE
Replace Pydantic ValueError with standard ValueError

### DIFF
--- a/osm_login_python/core.py
+++ b/osm_login_python/core.py
@@ -6,7 +6,6 @@ import logging
 
 from itsdangerous import BadSignature, SignatureExpired
 from itsdangerous.url_safe import URLSafeSerializer
-from pydantic import ValidationError
 from requests_oauthlib import OAuth2Session
 
 from . import Login, Token
@@ -103,6 +102,6 @@ class Auth:
             user_data = deserializer.loads(decoded_token)
         except (SignatureExpired, BadSignature) as e:
             log.error(e)
-            raise ValidationError("Invalid token") from e
+            raise ValueError("Auth token is invalid or expired") from e
 
         return user_data


### PR DESCRIPTION
The current implementation of `pydantic_core.ValidationError` did not work.
If the `except` was triggered here

```python
        try:
            user_data = deserializer.loads(decoded_token)
        except (SignatureExpired, BadSignature) as e:
```

we simply got: `no constructor defined`.

This is because pydantic ValidationError cannot be used directly.

Correct usage would be via the `from_exception_data` static method:

```python
raise ValidationError.from_exception_data(
                {
                    "type": "value_error",
                    "loc": ("access_token",),
                    "input": access_token,
                    "ctx": {
                        "error": "Auth token is invalid or expired",
                    },
                }
            )
```

However, IMO, this is overly complicated and we don't need to use pydantic for it.
A simple ValueError will suffice & is more maintainable.


**Additional context**
- We only use Pydantic for two very simple models.
- Pydantic could probably be refactored out eventually, reducing the dependencies required to install this package.