### PR TITLE
Return the raw OSM OAuth2 token in addition to `access_token`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Tests
+
+on:
+  push:
+    paths:
+      - osm_login_python/**
+      - tests/**
+      - pyproject.toml
+    branches: [main]
+  # Allow manual trigger (workflow_dispatch)
+  workflow_dispatch:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install deps
+        run: |
+          pip install pdm==2.17.3
+          pdm install
+
+      - name: Run tests
+        run: |
+          pdm run pytest

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ __pypackages__
 
 # MkDocs
 site
+
+# Coverage dir
+.coverage

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # osm-login-python
 
-Library to provide osm login oauth2.0 exchange to python projects
-
-Makes it very easier to implement osm authentication login to
-their project with oauth2.0
+Package to manage OAuth 2.0 login for OSM in Python.
 
 📖 [Documentation](https://hotosm.github.io/osm-login-python/)
 
@@ -28,30 +25,55 @@ osm_auth=Auth(
     client_secret=YOUR_OSM_CLIENT_SECRET,
     secret_key=YOUR_OSM_SECRET_KEY,
     login_redirect_uri=YOUR_OSM_LOGIN_REDIRECT_URI,
-    scope=YOUR_OSM_SCOPE,
+    scope=YOUR_OSM_SCOPE_LIST,
 )
 ```
 
 ## Usage
 
-Provides 3 Functions inside Auth class :
+Three functions are provided:
 
-1. login() -- Returns the login url for osm
-2. callback() -- Returns the access token for the user
-3. deserialize_access_token() -- returns the user data
+1. login() -- Returns the login url for OSM.
+
+   - The user must then access this URL and authorize the OAuth application
+     to login.
+   - The user will be redirected to the configured `login_redirect_uri` after
+     successful login with OSM.
+   - The web page must then call the `callback()` function below, sending the
+     current URL to the function (which includes the OAuth authorization code).
+
+2. callback() -- Returns the encoded and serialized data:
+
+   - `user_data` a JSON of OSM user data.
+   - `oauth_token` a string OSM OAuth token.
+   - Both are encoded and serialized as an additional safety measure when used
+     in URLs.
+
+3. deserialize_data() -- returns decoded and deserialized data from `callback()`.
+
+> [!NOTE]
+> This package is primarily intended to return OSM user data.
+>
+> It is also possible to obtain the `oauth_token` as described above, for making
+> authenticated requests against the OSM API from within a secure **backend**
+> service.
+>
+> To use the OAuth token in a **frontend** please use caution and adhere
+> to best practice security, such as embedding in a secure httpOnly cookie
+> (do not store in localStorage, sessionStorage, or unsecure cookies).
 
 ## Example
 
-On django :
+In Django:
 
 ```python
+import json
 from django.conf import settings
 from osm_login_python.core import Auth
 from django.http import JsonResponse
-import json
 
 # initialize osm_auth with our credentials
-osm_auth=Auth(
+osm_auth = Auth(
     osm_url=YOUR_OSM_URL,
     client_id=YOUR_OSM_CLIENT_ID,
     client_secret=YOUR_OSM_CLIENT_SECRET,
@@ -61,29 +83,29 @@ osm_auth=Auth(
 )
 
 def login(request):
-    login_url=osm_auth.login()
+    login_url = osm_auth.login()
     return JsonResponse(login_url)
 
 def callback(request):
     # Generating token through osm_auth library method
-    token=osm_auth.callback(request.build_absolute_uri())
+    token = osm_auth.callback(request.build_absolute_uri())
     return JsonResponse(token)
 
-def get_my_data(request,access_token: str):
-    user_data=osm_auth.deserialize_access_token(access_token)
+def get_my_data(request, serialized_user_data: str):
+    user_data = osm_auth.deserialize_data(serialized_user_data)
     return JsonResponse(user_data)
 ```
 
-- Check Django integration example here
+- Django integration example here
   <https://github.com/hotosm/fAIr/tree/master/backend/login>
 
-- Check FastAPI integration example here
+- FastAPI integration example here
   <https://github.com/hotosm/export-tool-api/tree/develop/API/auth>
 
 ### Version Control
 
-Use [commitizen](https://pypi.org/project/commitizen/) for version control
+Use [commitizen](https://pypi.org/project/commitizen/) for version control.
 
-### Contirbute
+### Contribute
 
-Contributions are welcome !
+Contributions are welcome!

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Package to manage OAuth 2.0 login for OSM in Python.
 
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/hotosm/osm-login-python/main.svg)](https://results.pre-commit.ci/latest/github/hotosm/osm-login-python/main)
 
+![coverage badge](./docs/coverage.svg)
+
 ## Install with [pip](https://pypi.org/project/osm-login-python/)
 
 ```bash
@@ -105,6 +107,17 @@ def get_my_data(request, serialized_user_data: str):
 ### Version Control
 
 Use [commitizen](https://pypi.org/project/commitizen/) for version control.
+
+### Test Coverage
+
+Generate a coverage badge:
+
+```bash
+pdm install
+pdm run coverage run -m pytest
+# pdm run coverage report
+pdm run coverage coverage-badge -o docs/coverage.svg
+```
 
 ### Contribute
 

--- a/docs/coverage.svg
+++ b/docs/coverage.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="a">
+        <rect width="99" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#a)">
+        <path fill="#555" d="M0 0h63v20H0z"/>
+        <path fill="#a4a61d" d="M63 0h36v20H63z"/>
+        <path fill="url(#b)" d="M0 0h99v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+        <text x="31.5" y="14">coverage</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">84%</text>
+        <text x="80" y="14">84%</text>
+    </g>
+</svg>

--- a/osm_login_python/__init__.py
+++ b/osm_login_python/__init__.py
@@ -13,3 +13,4 @@ class Token(BaseModel):
     """Model to return the access token."""
 
     access_token: str
+    raw_token: str

--- a/osm_login_python/__init__.py
+++ b/osm_login_python/__init__.py
@@ -10,7 +10,7 @@ class Login(BaseModel):
 
 
 class Token(BaseModel):
-    """Model to return the access token."""
+    """Model to return the user data and OSM OAuth token."""
 
-    access_token: str
-    raw_token: str
+    user_data: str
+    oauth_token: str

--- a/osm_login_python/core.py
+++ b/osm_login_python/core.py
@@ -18,6 +18,10 @@ class Auth:
 
     def __init__(self, osm_url, client_id, client_secret, secret_key, login_redirect_uri, scope):
         """Set object params and get OAuth2 session."""
+        # Strip trailing slash so our URL forming works
+        if osm_url.endswith("/"):
+            osm_url = osm_url.rstrip("/")
+
         self.osm_url = osm_url
         self.client_secret = client_secret
         self.secret_key = secret_key

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "test", "docs"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:cd04ce265dad1b94eb83b853d3337baf1a930e0ca891610b173cc8262f70cf78"
+content_hash = "sha256:562cc3d82a25f4def1d517a68f799f489cb73d60a97e6f8a58fe725f01024ac3"
 
 [[package]]
 name = "annotated-types"
@@ -131,6 +131,89 @@ summary = "Cross-platform colored terminal text."
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
+]
+
+[[package]]
+name = "coverage"
+version = "7.6.1"
+requires_python = ">=3.8"
+summary = "Code coverage measurement for Python"
+files = [
+    {file = "coverage-7.6.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b06079abebbc0e89e6163b8e8f0e16270124c154dc6e4a47b413dd538859af16"},
+    {file = "coverage-7.6.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cf4b19715bccd7ee27b6b120e7e9dd56037b9c0681dcc1adc9ba9db3d417fa36"},
+    {file = "coverage-7.6.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e61c0abb4c85b095a784ef23fdd4aede7a2628478e7baba7c5e3deba61070a02"},
+    {file = "coverage-7.6.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fd21f6ae3f08b41004dfb433fa895d858f3f5979e7762d052b12aef444e29afc"},
+    {file = "coverage-7.6.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f59d57baca39b32db42b83b2a7ba6f47ad9c394ec2076b084c3f029b7afca23"},
+    {file = "coverage-7.6.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a1ac0ae2b8bd743b88ed0502544847c3053d7171a3cff9228af618a068ed9c34"},
+    {file = "coverage-7.6.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e6a08c0be454c3b3beb105c0596ebdc2371fab6bb90c0c0297f4e58fd7e1012c"},
+    {file = "coverage-7.6.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f5796e664fe802da4f57a168c85359a8fbf3eab5e55cd4e4569fbacecc903959"},
+    {file = "coverage-7.6.1-cp310-cp310-win32.whl", hash = "sha256:7bb65125fcbef8d989fa1dd0e8a060999497629ca5b0efbca209588a73356232"},
+    {file = "coverage-7.6.1-cp310-cp310-win_amd64.whl", hash = "sha256:3115a95daa9bdba70aea750db7b96b37259a81a709223c8448fa97727d546fe0"},
+    {file = "coverage-7.6.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7dea0889685db8550f839fa202744652e87c60015029ce3f60e006f8c4462c93"},
+    {file = "coverage-7.6.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ed37bd3c3b063412f7620464a9ac1314d33100329f39799255fb8d3027da50d3"},
+    {file = "coverage-7.6.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d85f5e9a5f8b73e2350097c3756ef7e785f55bd71205defa0bfdaf96c31616ff"},
+    {file = "coverage-7.6.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9bc572be474cafb617672c43fe989d6e48d3c83af02ce8de73fff1c6bb3c198d"},
+    {file = "coverage-7.6.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0420b573964c760df9e9e86d1a9a622d0d27f417e1a949a8a66dd7bcee7bc6"},
+    {file = "coverage-7.6.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1f4aa8219db826ce6be7099d559f8ec311549bfc4046f7f9fe9b5cea5c581c56"},
+    {file = "coverage-7.6.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:fc5a77d0c516700ebad189b587de289a20a78324bc54baee03dd486f0855d234"},
+    {file = "coverage-7.6.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b48f312cca9621272ae49008c7f613337c53fadca647d6384cc129d2996d1133"},
+    {file = "coverage-7.6.1-cp311-cp311-win32.whl", hash = "sha256:1125ca0e5fd475cbbba3bb67ae20bd2c23a98fac4e32412883f9bcbaa81c314c"},
+    {file = "coverage-7.6.1-cp311-cp311-win_amd64.whl", hash = "sha256:8ae539519c4c040c5ffd0632784e21b2f03fc1340752af711f33e5be83a9d6c6"},
+    {file = "coverage-7.6.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:95cae0efeb032af8458fc27d191f85d1717b1d4e49f7cb226cf526ff28179778"},
+    {file = "coverage-7.6.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5621a9175cf9d0b0c84c2ef2b12e9f5f5071357c4d2ea6ca1cf01814f45d2391"},
+    {file = "coverage-7.6.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:260933720fdcd75340e7dbe9060655aff3af1f0c5d20f46b57f262ab6c86a5e8"},
+    {file = "coverage-7.6.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07e2ca0ad381b91350c0ed49d52699b625aab2b44b65e1b4e02fa9df0e92ad2d"},
+    {file = "coverage-7.6.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c44fee9975f04b33331cb8eb272827111efc8930cfd582e0320613263ca849ca"},
+    {file = "coverage-7.6.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:877abb17e6339d96bf08e7a622d05095e72b71f8afd8a9fefc82cf30ed944163"},
+    {file = "coverage-7.6.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:3e0cadcf6733c09154b461f1ca72d5416635e5e4ec4e536192180d34ec160f8a"},
+    {file = "coverage-7.6.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c3c02d12f837d9683e5ab2f3d9844dc57655b92c74e286c262e0fc54213c216d"},
+    {file = "coverage-7.6.1-cp312-cp312-win32.whl", hash = "sha256:e05882b70b87a18d937ca6768ff33cc3f72847cbc4de4491c8e73880766718e5"},
+    {file = "coverage-7.6.1-cp312-cp312-win_amd64.whl", hash = "sha256:b5d7b556859dd85f3a541db6a4e0167b86e7273e1cdc973e5b175166bb634fdb"},
+    {file = "coverage-7.6.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a4acd025ecc06185ba2b801f2de85546e0b8ac787cf9d3b06e7e2a69f925b106"},
+    {file = "coverage-7.6.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a6d3adcf24b624a7b778533480e32434a39ad8fa30c315208f6d3e5542aeb6e9"},
+    {file = "coverage-7.6.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0c212c49b6c10e6951362f7c6df3329f04c2b1c28499563d4035d964ab8e08c"},
+    {file = "coverage-7.6.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6e81d7a3e58882450ec4186ca59a3f20a5d4440f25b1cff6f0902ad890e6748a"},
+    {file = "coverage-7.6.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78b260de9790fd81e69401c2dc8b17da47c8038176a79092a89cb2b7d945d060"},
+    {file = "coverage-7.6.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a78d169acd38300060b28d600344a803628c3fd585c912cacc9ea8790fe96862"},
+    {file = "coverage-7.6.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2c09f4ce52cb99dd7505cd0fc8e0e37c77b87f46bc9c1eb03fe3bc9991085388"},
+    {file = "coverage-7.6.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6878ef48d4227aace338d88c48738a4258213cd7b74fd9a3d4d7582bb1d8a155"},
+    {file = "coverage-7.6.1-cp313-cp313-win32.whl", hash = "sha256:44df346d5215a8c0e360307d46ffaabe0f5d3502c8a1cefd700b34baf31d411a"},
+    {file = "coverage-7.6.1-cp313-cp313-win_amd64.whl", hash = "sha256:8284cf8c0dd272a247bc154eb6c95548722dce90d098c17a883ed36e67cdb129"},
+    {file = "coverage-7.6.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d3296782ca4eab572a1a4eca686d8bfb00226300dcefdf43faa25b5242ab8a3e"},
+    {file = "coverage-7.6.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:502753043567491d3ff6d08629270127e0c31d4184c4c8d98f92c26f65019962"},
+    {file = "coverage-7.6.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6a89ecca80709d4076b95f89f308544ec8f7b4727e8a547913a35f16717856cb"},
+    {file = "coverage-7.6.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a318d68e92e80af8b00fa99609796fdbcdfef3629c77c6283566c6f02c6d6704"},
+    {file = "coverage-7.6.1-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13b0a73a0896988f053e4fbb7de6d93388e6dd292b0d87ee51d106f2c11b465b"},
+    {file = "coverage-7.6.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4421712dbfc5562150f7554f13dde997a2e932a6b5f352edcce948a815efee6f"},
+    {file = "coverage-7.6.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:166811d20dfea725e2e4baa71fffd6c968a958577848d2131f39b60043400223"},
+    {file = "coverage-7.6.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:225667980479a17db1048cb2bf8bfb39b8e5be8f164b8f6628b64f78a72cf9d3"},
+    {file = "coverage-7.6.1-cp313-cp313t-win32.whl", hash = "sha256:170d444ab405852903b7d04ea9ae9b98f98ab6d7e63e1115e82620807519797f"},
+    {file = "coverage-7.6.1-cp313-cp313t-win_amd64.whl", hash = "sha256:b9f222de8cded79c49bf184bdbc06630d4c58eec9459b939b4a690c82ed05657"},
+    {file = "coverage-7.6.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:abd5fd0db5f4dc9289408aaf34908072f805ff7792632250dcb36dc591d24255"},
+    {file = "coverage-7.6.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:547f45fa1a93154bd82050a7f3cddbc1a7a4dd2a9bf5cb7d06f4ae29fe94eaf8"},
+    {file = "coverage-7.6.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:645786266c8f18a931b65bfcefdbf6952dd0dea98feee39bd188607a9d307ed2"},
+    {file = "coverage-7.6.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9e0b2df163b8ed01d515807af24f63de04bebcecbd6c3bfeff88385789fdf75a"},
+    {file = "coverage-7.6.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:609b06f178fe8e9f89ef676532760ec0b4deea15e9969bf754b37f7c40326dbc"},
+    {file = "coverage-7.6.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:702855feff378050ae4f741045e19a32d57d19f3e0676d589df0575008ea5004"},
+    {file = "coverage-7.6.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:2bdb062ea438f22d99cba0d7829c2ef0af1d768d1e4a4f528087224c90b132cb"},
+    {file = "coverage-7.6.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:9c56863d44bd1c4fe2abb8a4d6f5371d197f1ac0ebdee542f07f35895fc07f36"},
+    {file = "coverage-7.6.1-cp39-cp39-win32.whl", hash = "sha256:6e2cd258d7d927d09493c8df1ce9174ad01b381d4729a9d8d4e38670ca24774c"},
+    {file = "coverage-7.6.1-cp39-cp39-win_amd64.whl", hash = "sha256:06a737c882bd26d0d6ee7269b20b12f14a8704807a01056c80bb881a4b2ce6ca"},
+    {file = "coverage-7.6.1-pp38.pp39.pp310-none-any.whl", hash = "sha256:e9a6e0eb86070e8ccaedfbd9d38fec54864f3125ab95419970575b42af7541df"},
+    {file = "coverage-7.6.1.tar.gz", hash = "sha256:953510dfb7b12ab69d20135a0662397f077c59b1e6379a768e97c59d852ee51d"},
+]
+
+[[package]]
+name = "coverage-badge"
+version = "1.1.2"
+summary = "Generate coverage badges for Coverage.py."
+dependencies = [
+    "coverage",
+    "setuptools",
+]
+files = [
+    {file = "coverage_badge-1.1.2-py2.py3-none-any.whl", hash = "sha256:d8413ce51c91043a1692b943616b450868cbeeb0ea6a0c54a32f8318c9c96ff7"},
+    {file = "coverage_badge-1.1.2.tar.gz", hash = "sha256:fe7ed58a3b72dad85a553b64a99e963dea3847dcd0b8ddd2b38a00333618642c"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -3,10 +3,9 @@
 
 [metadata]
 groups = ["default", "test", "docs"]
-cross_platform = true
-static_urls = false
-lock_version = "4.3"
-content_hash = "sha256:7d40601e6b190608d76bbb09dd293ecb0c4efed215f1d41c1a93098a0572ce28"
+strategy = ["cross_platform"]
+lock_version = "4.4.1"
+content_hash = "sha256:cd04ce265dad1b94eb83b853d3337baf1a930e0ca891610b173cc8262f70cf78"
 
 [[package]]
 name = "annotated-types"
@@ -622,6 +621,19 @@ dependencies = [
 files = [
     {file = "pytest-7.4.3-py3-none-any.whl", hash = "sha256:0d009c083ea859a71b76adf7c1d502e4bc170b80a8ef002da5806527b9591fac"},
     {file = "pytest-7.4.3.tar.gz", hash = "sha256:d989d136982de4e3b29dabcc838ad581c64e8ed52c11fbe86ddebd9da0818cd5"},
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.14.0"
+requires_python = ">=3.8"
+summary = "Thin-wrapper around the mock package for easier use with pytest"
+dependencies = [
+    "pytest>=6.2.5",
+]
+files = [
+    {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
+    {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ repository = "https://github.com/hotosm/osm-login-python"
 [project.optional-dependencies]
 test = [
     "pytest>=7.4.2",
+    "pytest-mock>=3.14.0",
 ]
 docs = [
     "mkdocs>=1.5.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "osm-login-python"
 version = "1.0.3"
 dynamic = ["version"]
-description = "Use OSM Token exchange with OAuth2.0 for python projects."
+description = "Package to manage OAuth 2.0 login for OSM in Python."
 readme = "README.md"
 authors = [
     {name = "Kshitij Raj Sharma", email = "skshitizraj@gmail.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ description = "Package to manage OAuth 2.0 login for OSM in Python."
 readme = "README.md"
 authors = [
     {name = "Kshitij Raj Sharma", email = "skshitizraj@gmail.com"},
+    {name = "Sam Woodcock", email = "sam.woodcock@protonmail.com"},
 ]
 license = {text = "GPL-3.0-only"}
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ repository = "https://github.com/hotosm/osm-login-python"
 test = [
     "pytest>=7.4.2",
     "pytest-mock>=3.14.0",
+    "coverage>=7.6.1",
+    "coverage-badge>=1.1.2",
 ]
 docs = [
     "mkdocs>=1.5.3",
@@ -90,3 +92,9 @@ exclude = [
 select = ["I", "E", "W", "D", "B", "F", "N", "Q"]
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.coverage.run]
+source = ["osm_login_python"]
+
+[tool.coverage.report]
+show_missing = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Configure fixtures for testing."""
+
+import pytest
+
+from osm_login_python.core import Auth
+
+
+@pytest.fixture
+def auth():
+    """Setup the Auth object."""
+    return Auth(
+        osm_url="https://www.openstreetmap.org",
+        client_id="xxxxx",
+        client_secret="xxxxx",
+        secret_key="superdupersecretkey",
+        login_redirect_uri="https://someurl.com/callback",
+        scope="read_prefs",
+    )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,1 +1,47 @@
 """Test the main module logic."""
+
+
+def test_serialize_deserialize(auth):
+    """Simple check to see if the serialization works as intended."""
+    dummy_osm_token = "jdsifcjh984h3fhj40efh4j39t8gh4eg985tr"
+    serialized_dummy_osm_token = auth._serialize_encode_data(dummy_osm_token)
+    deserialized_dummy_osm_token = auth.deserialize_data(serialized_dummy_osm_token)
+
+    assert deserialized_dummy_osm_token == dummy_osm_token
+
+
+def test_login(auth, mocker):
+    """Test the login() method returns a URL."""
+    # Mock the return value for the Login model
+    mocker.patch.object(auth.oauth, "authorization_url", return_value=("https://openstreetmap.org/oauth2/authorize", "state"))
+    mock_login_instance = mocker.Mock()
+    mock_login_instance.model_dump_json.return_value = '{"login_url": "https://openstreetmap.org/oauth2/authorize"}'
+    mocker.patch("osm_login_python.core.Login", return_value=mock_login_instance)
+
+    # Test the login method using mock data
+    result = auth.login()
+    assert result == {"login_url": "https://openstreetmap.org/oauth2/authorize"}
+
+
+def test_callback(auth, mocker):
+    """Test the callback() method returns serialized data."""
+    # Patch the requests_oauthlib fetch_token method with a mock access_token
+    mocker.patch.object(auth.oauth, "fetch_token", return_value={"access_token": "fswfhewuihfewuhew"})
+
+    # Mock OSM user data and patch GET request
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "user": {"id": 12345, "display_name": "testuser", "img": {"href": "https://example.com/image.jpg"}}
+    }
+    mocker.patch.object(auth.oauth, "get", return_value=mock_response)
+
+    # Compare expected responses with actual responses from callback()
+    api_result = auth.callback("https://example.com/callback")
+
+    expected_user_data = auth._serialize_encode_data(
+        {"id": 12345, "username": "testuser", "img_url": "https://example.com/image.jpg"}
+    )
+    expected_oauth_token = auth._serialize_encode_data("fswfhewuihfewuhew")
+
+    assert api_result == {"user_data": expected_user_data, "oauth_token": expected_oauth_token}


### PR DESCRIPTION
> [!WARNING]
> Initially I made this as a backward compatible change.
>
> However I decided to tweak the API slightly to better clarify what things too, making it easier to maintain this into the future.
>
> Users wishing to use the same API can use package version `==1.0.3` without issues and not upgrade.

**Problem**

- The `access_token` supplied from this module can only be deserialised and used by this module to get user data.
- It would be great to have access to the OSM OAuth2 token so the user can call additional OSM endpoints if required.

**Included in this PR - main updates**

- I added some comments to the code in `callback` to describe what is happening.
- Updated the returned dictionary from `callback` to include both `user_data` and `oauth_token`:
  - `user_data` replaces `access_token` we have currently. Although this would better be described as `encoded_user_data`, as it's not an access token nor a JSON of data!
  - `oauth_token` is the OSM OAuth2 access token we can use to call endpoints. Users of this module keeping their code as it is can just ignore this / discard the value if not required. However it is useful to have this value if we want to use it in our backend API.
- The `oauth_token` could be stored in a secure httpOnly cookie from a backend API for persistence, then extracted when we call our backend API for further calls to the OSM API.
- I also renamed `deserialize_access_token` to just `deserialize_data` as we reuse this function for both `user_data` and `oauth_token` now.

**Included in this PR - extras**

- Strips trailing slash from `osm_url` during init, if present.
- Added unit tests for all functionality.
- Added coverage for tests.
- And added a small workflow to run tests on push / PR.

> [!NOTE] 
> Ideally we would call the OSM API from the frontend, however we have no good secure way to store the OSM token outside of a secure httpOnly cookie. OSM will not accept a cookie as auth (they need an `Authorization` header), so this means all OSM API requests need to be mediated by a backend API server we own. The request is sent to our server, the token is extracted from the cookie, then the request is made to OSM and details returned to the frontend.